### PR TITLE
Update permissions in workflow files

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,10 +11,12 @@ on:
     paths:
       - .github/workflows/**
 
-permissions: write-all
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -34,4 +36,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.repository_owner == 'nowsprinting' # Skip public fork, because can not read secrets.
+        if: failure() && github.repository_owner == 'nowsprinting' # Skip on public fork, because can not read secrets.

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -13,10 +13,12 @@ on:
       - .github/workflows/hadolint.yml
       - Dockerfile
 
-permissions: write-all
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -35,4 +37,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.repository_owner == 'nowsprinting' # Skip public fork, because can not read secrets.
+        if: failure() && github.repository_owner == 'nowsprinting' # Skip on public fork, because can not read secrets.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     types: [ opened ]
 
-permissions: write-all
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: TimonVS/pr-labeler-action@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,10 +10,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: write-all
 jobs:
   release-drafter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,10 +13,12 @@ on:
       - .github/workflows/shellcheck.yml
       - '**.sh'
 
-permissions: write-all
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -33,4 +35,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.repository_owner == 'nowsprinting' # Skip public fork, because can not read secrets.
+        if: failure() && github.repository_owner == 'nowsprinting' # Skip on public fork, because can not read secrets.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: write-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -72,6 +73,8 @@ jobs:
 
   test-on-container:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: ghcr.io/nowsprinting/diff-pdf:latest
 
@@ -83,6 +86,8 @@ jobs:
     needs: [ test, test-on-container ]
     if: failure()
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
 
     steps:
       - uses: Gamesight/slack-workflow-status@v1.2.0

--- a/.github/workflows/update-major.yml
+++ b/.github/workflows/update-major.yml
@@ -7,10 +7,11 @@ on:
   release:
     types: [ published ]
 
-permissions: write-all
 jobs:
   update-major:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: nowsprinting/check-version-format-action@v3

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Unable to init server: Could not connect: Connection refused
 jobs:
   diff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -83,6 +85,8 @@ jobs:
 jobs:
   diff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -100,6 +104,8 @@ jobs:
 jobs:
   diff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: ghcr.io/nowsprinting/diff-pdf:latest
 


### PR DESCRIPTION
Updated the permissions in various GitHub Actions workflows from blanket 'write-all' permissions to more specific 'read' or 'write' permissions for individual components like 'contents', 'actions', and 'pull-requests'. The change improves the security posture by granting least needed privilege to these workflows and follows the principle of least privilege (PoLP) as well as better aligns with GitHub's tightened permissions policy.
